### PR TITLE
Chore: Updated Blog and removed `cd frontend`

### DIFF
--- a/samples/apps/autogen-studio/README.md
+++ b/samples/apps/autogen-studio/README.md
@@ -111,7 +111,7 @@ The agent workflow responds by _writing and executing code_ to create a python p
 ## FAQ
 
 **Q: Where can I adjust the default skills, agent and workflow configurations?**
-A: You can modify agent configurations directly from the UI or by editing the [dbdefaults.json](autogentstudio/utils/dbdefaults.json) file which is used to initialize the database.
+A: You can modify agent configurations directly from the UI or by editing the [dbdefaults.json](autogenstudio/utils/dbdefaults.json) file which is used to initialize the database.
 
 **Q: If I want to reset the entire conversation with an agent, how do I go about it?**
 A: To reset your conversation history, you can delete the `database.sqlite` file. If you need to clear user-specific data, remove the relevant `autogenstudio/web/files/user/<user_id_md5hash>` folder.

--- a/website/blog/2023-12-01-AutoGenStudio/index.mdx
+++ b/website/blog/2023-12-01-AutoGenStudio/index.mdx
@@ -95,7 +95,6 @@ llm_config = LLMConfig(
      ```bash
      npm install -g gatsby-cli
      npm install --global yarn
-     cd frontend
      yarn install
      yarn build
      ```


### PR DESCRIPTION


## Why are these changes needed?
User is already in the frontend directory so there is no need to run `cd frontend` so it improves the docs better.

## Related issue number
None

## Checks

- [x] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
